### PR TITLE
 Migrate prompt parsing to magic commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ ICortex is a [Jupyter kernel](https://jupyter-client.readthedocs.io/en/latest/ke
 
 https://user-images.githubusercontent.com/2453968/196814906-1a0de2a1-27a7-4aec-a960-0eb21fbe2879.mp4
 
+TODO: Prompts are given using the %prompt magic now, update the video accordingly
+
 It is ...
 
 - a drop-in replacement for the IPython kernel. Prompts can be executed with the [magic commands](https://ipython.readthedocs.io/en/stable/interactive/magics.html) `%prompt` or `%p` for short.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ https://user-images.githubusercontent.com/2453968/196814906-1a0de2a1-27a7-4aec-a
 
 It is ...
 
-- a drop-in replacement for the IPython kernel. Prompts start with a forward slash `/`—otherwise the line is treated as regular Python code.
+- a drop-in replacement for the IPython kernel. Prompts can be executed with the [magic commands](https://ipython.readthedocs.io/en/stable/interactive/magics.html) `%prompt` or `%p` for short.
 - an interface for [Natural Language Programming](https://en.wikipedia.org/wiki/Natural-language_programming) interface—prompts written in plain English automatically generate Python code which can then be executed globally.
 - interactive—install missing packages directly, decide whether to execute the generated code or not, and so on, directly in the Jupyter Notebook cell.
 - open source and fully extensible—if you think we are missing a model or an API, you can request it by creating an issue, or implement it yourself by subclassing `ServiceBase` under [`icortex/services`](icortex/services).
@@ -40,7 +40,7 @@ icortex init
 Alternatively, you can initialize directly in a Jupyter Notebook ([instructions on how to start JupyterLab](https://jupyterlab.readthedocs.io/en/stable/getting_started/starting.html)):
 
 ```
-//init
+%icortex init
 ```
 
 The shell will then instruct you step by step and create a configuration file `icortex.toml` in the current directory.
@@ -65,10 +65,10 @@ You can also try out different services e.g. OpenAI's Codex API, if you have acc
 
 ### Executing prompts
 
-To execute a prompt with ICortex, use the `/` character (forward slash, also used to denote division) as a prefix. Copy and paste the following prompt into a cell and try to run it:
+To execute a prompt with ICortex, use the `%prompt` [magic command](https://ipython.readthedocs.io/en/stable/interactive/magics.html) (or `%p` for short) as a prefix. Copy and paste the following prompt into a cell and try to run it:
 
 ```
-/print Hello World. Then print the Fibonacci numbers till 100
+%p print Hello World. Then print the Fibonacci numbers till 100
 ```
 
 Depending on the response, you should see an output similar to the following:
@@ -87,7 +87,7 @@ Hello World.
 You can also specify variables or options with command line flags, e.g. to auto-install packages, auto-execute the returned code and so on. To see the complete list of variables for your chosen service, run:
 
 ```
-/help
+%help
 ```
 
 ### Using ICortex CLI
@@ -106,7 +106,7 @@ icortex service help
 
 ### Accessing ICortex CLI inside Jupyter
 
-You can still access the `icortex` CLI in a Jupyter Notebook or shell by using the prefix `//`. For example running the following in the terminal switches to a local HuggingFace model:
+You can still access the `icortex` CLI in a Jupyter Notebook or shell by using the magic command `%icortex`. For example running the following in the terminal switches to a local HuggingFace model:
 
 ```
 icortex service set huggingface
@@ -115,7 +115,7 @@ icortex service set huggingface
 To do the same in a Jupyter Notebook, you can run
 
 ```
-//service set huggingface
+%icortex service set huggingface
 ```
 
 in a cell, which initializes and switches to the new service directly in your Jupyter session.

--- a/docs/source/specification.rst
+++ b/docs/source/specification.rst
@@ -1,0 +1,5 @@
+
+ICortex Specification
+=====================
+
+Some stuff

--- a/icortex/__init__.py
+++ b/icortex/__init__.py
@@ -1,4 +1,4 @@
-from icortex.kernel import ICortexKernel, print_help, get_icortex_kernel
+from icortex.kernel import ICortexKernel, print_service_help, get_icortex_kernel
 
 import icortex.services
 import importlib.metadata

--- a/icortex/cli.py
+++ b/icortex/cli.py
@@ -20,7 +20,7 @@ def get_parser(prog=None):
     # Initialize ICortex #
     ######################
 
-    # //init
+    # icortex init
     parser_init = subparsers.add_parser(
         "init",
         help="Initialize ICortex configuration in the current directory",
@@ -42,7 +42,7 @@ def get_parser(prog=None):
     # Shell related commands #
     ##########################
 
-    # //shell
+    # icortex shell
     parser_shell = subparsers.add_parser(
         "shell",
         help="Start ICortex shell",
@@ -53,7 +53,7 @@ def get_parser(prog=None):
     # Help #
     ########
 
-    # //help
+    # icortex help
     parser_help = subparsers.add_parser(
         "help",
         help="Print help",
@@ -64,7 +64,7 @@ def get_parser(prog=None):
     # Service related commands #
     ############################
 
-    # //service
+    # icortex service
     parser_service = subparsers.add_parser(
         "service",
         help="Set and configure code generation services",
@@ -75,7 +75,7 @@ def get_parser(prog=None):
         required=True,
     )
 
-    # //service set <service_name>
+    # icortex service set <service_name>
     parser_service_commands_set = parser_service_commands.add_parser(
         "set",
         help="Set the service to be used for code generation",
@@ -87,21 +87,21 @@ def get_parser(prog=None):
         help="Name of the service to be used for code generation",
     )
 
-    # //service show <service_name>
+    # icortex service show <service_name>
     parser_service_commands_show = parser_service_commands.add_parser(
         "show",
         help="Show current service",
         add_help=False,
     )
 
-    # //service help
+    # icortex service help
     parser_service_commands_help = parser_service_commands.add_parser(
         "help",
-        help="Print help for //service",
+        help="Print help for the current service",
         add_help=False,
     )
 
-    # //service set-var <variable_name> <variable_value>
+    # icortex service set-var <variable_name> <variable_value>
     parser_service_commands_set_var = parser_service_commands.add_parser(
         "set-var",
         help="Set a variable for the current service",
@@ -117,7 +117,7 @@ def get_parser(prog=None):
         help="New value for the variable",
     )
 
-    # //service init <service_name>
+    # icortex service init <service_name>
     # Used to re-spawn the config dialog if some config for the service
     # already exists
     parser_service_commands_init = parser_service_commands.add_parser(
@@ -198,7 +198,7 @@ def main(argv=None, prog=None, kernel=None):
 def eval_cli(prompt: str):
     argv = shlex.split(prompt)
     try:
-        return main(argv=argv, prog="//")
+        return main(argv=argv, prog=r"%icortex")
     except SystemExit:
         return
 

--- a/icortex/context.py
+++ b/icortex/context.py
@@ -48,8 +48,12 @@ class ICortexHistory:
 
         self._dict = self.scope[DEFAULT_HISTORY_VAR]
 
-    def get_dict(self):
-        return deepcopy(self._dict)
+    def get_dict(self, omit_last_cell=False):
+        ret = deepcopy(self._dict)
+        if omit_last_cell:
+            if len(ret["cells"]) > 0:
+                del ret["cells"][-1]
+        return ret
 
     def add_code(self, code: str, outputs: t.List[t.Any]):
         self._check_init()

--- a/icortex/helper.py
+++ b/icortex/helper.py
@@ -8,11 +8,16 @@ def unescape(s) -> str:
 
 
 def is_prompt(input: str) -> bool:
-    return input.strip()[0] == "/"
+    return input.strip().split()[0] in [
+        r"%p",
+        r"%prompt",
+        r"%%prompt",
+        r"%%prompt",
+    ]
 
 
 def is_cli(input: str) -> bool:
-    return input.strip()[:2] == "//"
+    return input.strip().split()[0] == r"%icortex"
 
 
 def escape_quotes(s: str) -> str:
@@ -20,11 +25,14 @@ def escape_quotes(s: str) -> str:
 
 
 def extract_prompt(input: str) -> str:
-    return input.strip()[1:].strip()
+    tokens = input.strip().split(" ", 1)
+    if len(tokens) == 1:
+        return ""
+    else:
+        return tokens[1]
 
 
-def extract_cli(input: str) -> str:
-    return input.strip()[2:].strip()
+extract_cli = extract_prompt
 
 
 def yes_no_input(message: str, default=True) -> bool:

--- a/icortex/kernel/__main__.py
+++ b/icortex/kernel/__main__.py
@@ -1,3 +1,4 @@
+import IPython
 from icortex.kernel import ICortexKernel
 from ipykernel.kernelapp import IPKernelApp
 

--- a/icortex/magics.py
+++ b/icortex/magics.py
@@ -1,0 +1,43 @@
+from IPython.core.magic import (
+    Magics,
+    magics_class,
+    line_magic,
+    cell_magic,
+    line_cell_magic,
+)
+
+from icortex.kernel import get_icortex_kernel, print_service_help
+
+
+@magics_class
+class ICortexMagics(Magics):
+    @line_magic
+    def help(self, line):
+        print_service_help()
+        return
+
+    @line_magic
+    def icortex(self, line):
+        kernel = get_icortex_kernel()
+        return kernel.cli(line)
+
+    @line_cell_magic
+    def prompt(self, line, cell=None):
+        if cell is None:
+            return self._prompt(line)
+        else:
+            return self._prompt(line + " " + cell)
+
+    @line_cell_magic
+    def p(self, line, cell=None):
+        "Alias for prompt()"
+        return self.prompt(line, cell=cell)
+
+    def _prompt(self, input_):
+        kernel = get_icortex_kernel()
+        return kernel.prompt(input_)
+
+
+def load_ipython_extension(ipython):
+    "Register magics for ICortex"
+    ipython.register_magics(ICortexMagics)

--- a/icortex/services/service_base.py
+++ b/icortex/services/service_base.py
@@ -118,7 +118,7 @@ class ServiceBase(ABC):
             required=False,
             help="Do not print the generated code.",
         )
-        self.prompt_parser.usage = "/your prompt goes here [-e] [-r] [-i] [-p] ..."
+        self.prompt_parser.usage = "%p your prompt goes here [-e] [-r] [-i] [-p] ..."
 
         self.prompt_parser.description = self.description
 


### PR DESCRIPTION
#12 was previously created to address the hacky way prompts are parsed and generated code is executed. Now, IPython [magic commands](https://ipython.readthedocs.io/en/stable/interactive/magics.html) seem like an even better solution that uses the existing API and solves the issues stated there.

### TODO
- [x] Created `%prompt` and `%p` magics to replace `/`
- [x] Created `%icortex` magic to replace `//`
- [x] Save execution output to ICortexHistory
- [x] Print expression values for lines that have expressions and are also in the global scope